### PR TITLE
Create new query to get daily entry for a user based on time

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -35,7 +35,7 @@ type Query {
   editors(ID: ID): [Editor!]!
   entries(ID: ID): [Entry!]!
   entriesByUserID(userID: ID!, startDate: String, endDate: String): [Entry!]!
-  latestEntry(userID: ID!): Entry!
+  dailyEntry(userID: ID!, date: String!): Entry!
 }
 
 input NewUser {


### PR DESCRIPTION
This PR removes `latestEntry` and replaces it with a `dailyEntry` query. This will use a user's timezone to create daily entries (on their midnight) to ensure a new entry is truly created per day.