### PR TITLE
Add the ability to start a streak

### DIFF
--- a/db/wrabit.sql
+++ b/db/wrabit.sql
@@ -33,6 +33,7 @@ CREATE TABLE streaks (
   id SERIAL,
   user_id VARCHAR,
   day_count INT,
+  last_entry_id INT,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );

--- a/graphql/gqlgen.yml
+++ b/graphql/gqlgen.yml
@@ -14,6 +14,8 @@ models:
     model: github.com/writewithwrabit/server/graphql.Editor
   Entry:
     model: github.com/writewithwrabit/server/graphql.Entry
+  Streak:
+    model: github.com/writewithwrabit/server/graphql.Streak
 resolver:
   filename: resolver.go
   type: Resolver

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -6,6 +6,7 @@ type ExistingEntry struct {
 	UserID    string `json:"userID"`
 	WordCount int    `json:"wordCount"`
 	Content   string `json:"content"`
+	GoalHit   bool   `json:"goalHit"`
 }
 
 type NewEditor struct {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -29,6 +29,15 @@ type Editor {
   updatedAt: String!
 }
 
+type Streak {
+  id: ID!
+  User: User!
+  dayCount: Int!
+  lastEntryID: String!
+  createdAt: String!
+  updatedAt: String!
+}
+
 type Query {
   user(ID: String): User!
   userByFirebaseID(firebaseID: String): User!
@@ -64,6 +73,7 @@ input ExistingEntry {
   userID: String!
   wordCount: Int!
   content: String!
+  goalHit: Boolean!
 }
 
 input NewEditor {
@@ -83,7 +93,7 @@ type Mutation {
   createUser(input: NewUser!): User!
   updateUser(input: UpdatedUser!): User!
   createEntry(input: NewEntry!): Entry!
-  updateEntry(id: ID!, input: ExistingEntry!): Entry!
+  updateEntry(id: ID!, input: ExistingEntry!, date: String!): Entry!
   createEditor(input: NewEditor!): Editor!
   createSubscription(input: NewSubscription!): String!
 }

--- a/graphql/streak.go
+++ b/graphql/streak.go
@@ -1,0 +1,10 @@
+package server
+
+type Streak struct {
+	ID          string `json:"id"`
+	UserID      string `json:"userId"`
+	DayCount    int    `json:"dayCount"`
+	LastEntryID string `json:"lastEntryId"`
+	CreatedAt   string `json:"createdAt"`
+	UpdatedAt   string `json:"updatedAt"`
+}


### PR DESCRIPTION
This PR:
- [x] Adds `last_entry_id` to the `streaks` table to make it easy to see if a user's streak should be incremented
- [x] Adds a `Streak` type and a resolver for that type
- [x] Creates a streak for a user if they have hit their goal and aren't currently on a streak
- [x] Updates a streak for a user if they have hit their goal and are currently on a streak