### PR TITLE
Save goal hit boolean to database

### DIFF
--- a/db/wrabit.sql
+++ b/db/wrabit.sql
@@ -25,6 +25,7 @@ CREATE TABLE entries (
   user_id VARCHAR,
   word_count INT,
   content TEXT,
+  goal_hit BOOLEAN DEFAULT false,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );

--- a/graphql/entry.go
+++ b/graphql/entry.go
@@ -5,6 +5,7 @@ type Entry struct {
 	UserID    string `json:"userId"`
 	WordCount int    `json:"wordCount"`
 	Content   string `json:"content"`
+	GoalHit   bool   `json:"goalHit"`
 	CreatedAt string `json:"createdAt"`
 	UpdatedAt string `json:"updatedAt"`
 }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -15,6 +15,7 @@ type Entry {
   User: User!
   wordCount: Int!
   content: String!
+  goalHit: Boolean!
   createdAt: String!
   updatedAt: String!
 }


### PR DESCRIPTION
This PR:
- [x] Adds a `goal_hit` boolean to the database
- [x] Updates all GraphQL queries to use the new column

This column will allow me to visually show entries that have hit the goal easier (taking some client side computation away).