### PR TITLE
Add the ability to cancel a subscription

### DIFF
--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -26,6 +26,7 @@ type NewSubscription struct {
 	StripeID       string `json:"stripeId"`
 	TokenID        string `json:"tokenId"`
 	SubscriptionID string `json:"subscriptionId"`
+	Trial          bool   `json:"trial"`
 }
 
 type NewUser struct {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -118,6 +118,7 @@ input NewSubscription {
   stripeId: String!
   tokenId: String!
   subscriptionId: String!
+  trial: Boolean!
 }
 
 type Mutation {
@@ -126,5 +127,6 @@ type Mutation {
   createEntry(input: NewEntry!): Entry!
   updateEntry(id: ID!, input: ExistingEntry!, date: String!): Entry!
   createEditor(input: NewEditor!): Editor!
-  createSubscription(input: NewSubscription!): String!
+  createSubscription(input: NewSubscription!): StripeSubscription!
+  cancelSubscription(id: ID!): String!
 }


### PR DESCRIPTION
This PR:
- [x] Adds a new mutation for cancelling a subscription
- [x] Returns a subscription object when creating a subscription
- [x] Makes the trial of a new subscription to be configurable