### PR TITLE
Update to proper go runtime

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,1 +1,1 @@
-runtime: go
+runtime: go113

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/writewithwrabit/server
 
-go 1.12
+go 1.13
 
 require (
 	firebase.google.com/go v3.9.0+incompatible
@@ -11,6 +11,7 @@ require (
 	github.com/gobuffalo/envy v1.8.1 // indirect
 	github.com/joho/godotenv v1.3.0
 	github.com/lib/pq v1.2.0
+	github.com/mailgun/mailgun-go v2.0.0+incompatible
 	github.com/mailgun/mailgun-go/v3 v3.6.2
 	github.com/sqreen/go-agent v0.1.0-beta.7
 	github.com/stripe/stripe-go v63.2.2+incompatible

--- a/graphql/resolver.go
+++ b/graphql/resolver.go
@@ -8,9 +8,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
-	"time"
 
-	"github.com/mailgun/mailgun-go/v3"
+	"github.com/mailgun/mailgun-go"
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/card"
 	"github.com/stripe/stripe-go/customer"
@@ -176,10 +175,7 @@ func (r *mutationResolver) CompleteUserSignup(ctx context.Context, input SignedU
 	// message.SetTemplate("app-template")
 	// message.AddTemplateVariable("passwordResetLink", "some link to your site unique to your user")
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-	defer cancel()
-
-	_, _, err := mg.Send(ctx, message)
+	_, _, err := mg.Send(message)
 
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
This PR:
- [x] Updates the Google App Engine runtime to `go113`