### PR TITLE
Use user time to compare last entry

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -97,7 +97,7 @@ type ComplexityRoot struct {
 		Stats            func(childComplexity int, global bool) int
 		User             func(childComplexity int, id *string) int
 		UserByFirebaseID func(childComplexity int, firebaseID *string) int
-		WordGoal         func(childComplexity int, userID string) int
+		WordGoal         func(childComplexity int, userID string, date string) int
 	}
 
 	Stats struct {
@@ -164,7 +164,7 @@ type QueryResolver interface {
 	EntriesByUserID(ctx context.Context, userID string, startDate *string, endDate *string) ([]*Entry, error)
 	DailyEntry(ctx context.Context, userID string, date string) (*Entry, error)
 	Stats(ctx context.Context, global bool) (*Stats, error)
-	WordGoal(ctx context.Context, userID string) (int, error)
+	WordGoal(ctx context.Context, userID string, date string) (int, error)
 }
 type StreakResolver interface {
 	User(ctx context.Context, obj *Streak) (*User, error)
@@ -515,7 +515,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.WordGoal(childComplexity, args["userID"].(string)), true
+		return e.complexity.Query.WordGoal(childComplexity, args["userID"].(string), args["date"].(string)), true
 
 	case "Stats.longestEntry":
 		if e.complexity.Stats.LongestEntry == nil {
@@ -846,7 +846,7 @@ type Query {
   entriesByUserID(userID: ID!, startDate: String, endDate: String): [Entry!]!
   dailyEntry(userID: ID!, date: String!): Entry!
   stats(global: Boolean!): Stats!
-  wordGoal(userID: ID!): Int!
+  wordGoal(userID: ID!, date: String!): Int!
 }
 
 input NewUser {
@@ -1189,6 +1189,14 @@ func (ec *executionContext) field_Query_wordGoal_args(ctx context.Context, rawAr
 		}
 	}
 	args["userID"] = arg0
+	var arg1 string
+	if tmp, ok := rawArgs["date"]; ok {
+		arg1, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["date"] = arg1
 	return args, nil
 }
 
@@ -2617,7 +2625,7 @@ func (ec *executionContext) _Query_wordGoal(ctx context.Context, field graphql.C
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().WordGoal(rctx, args["userID"].(string))
+		return ec.resolvers.Query().WordGoal(rctx, args["userID"].(string), args["date"].(string))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/graphql/resolver.go
+++ b/graphql/resolver.go
@@ -588,7 +588,7 @@ func (r *queryResolver) DailyEntry(ctx context.Context, userID string, date stri
 	return entry, nil
 }
 
-func (r *queryResolver) WordGoal(ctx context.Context, userID string) (int, error) {
+func (r *queryResolver) WordGoal(ctx context.Context, userID string, date string) (int, error) {
 	ctxUser := auth.ForContext(ctx)
 	if ctxUser == nil || ctxUser.Subject != userID {
 		return 0, fmt.Errorf("Access denied")
@@ -618,7 +618,7 @@ func (r *queryResolver) WordGoal(ctx context.Context, userID string) (int, error
 
 	// Figure out when the last entry was written
 	// Is 0 if they wrote within 24 hours
-	res = wrabitDB.LogAndQueryRow(r.db, "SELECT date_part('day', NOW() - created_at::timestamp) As day_since_last_entry, id FROM entries WHERE user_id = $1 AND goal_hit = true ORDER BY created_at DESC LIMIT 1;", userID)
+	res = wrabitDB.LogAndQueryRow(r.db, "SELECT date_part('day', $1 - created_at::timestamp) As day_since_last_entry, id FROM entries WHERE user_id = $2 AND goal_hit = true ORDER BY created_at DESC LIMIT 1;", date, userID)
 	err = res.Scan(&daySinceLastWrote, &entryID)
 	if err != nil && err != sql.ErrNoRows {
 		panic(err)

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -76,7 +76,7 @@ type Query {
   entriesByUserID(userID: ID!, startDate: String, endDate: String): [Entry!]!
   dailyEntry(userID: ID!, date: String!): Entry!
   stats(global: Boolean!): Stats!
-  wordGoal(userID: ID!): Int!
+  wordGoal(userID: ID!, date: String!): Int!
 }
 
 input NewUser {


### PR DESCRIPTION
This PR:
- [x] Uses a user's time to see how many days since they last wrote; this was necessary because they could have their word goal reset to 100 if they wrote after the server (but not their timezone) hit midnight