### PR TITLE
Adjust donation logic to save on calls

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,7 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.4.0 h1:yxQ63CFIA8Sxkh0vqIofuNrsXl/LZ42TpeTLV4Nb5HM=
 github.com/DATA-DOG/go-sqlmock v1.4.0/go.mod h1:3TucWNLPFOLcHhha1CPp7Kis1UG2h/AqGROPyOeZzsM=
+github.com/DATA-DOG/go-sqlmock v1.4.1 h1:ThlnYciV1iM/V0OSF/dtkqWb6xo5qITT1TJBG1MRDJM=
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/GoogleCloudPlatform/cloudsql-proxy v0.0.0-20200114205427-eb5e09ef70a5 h1:LsOdhR5HaGRDZW/qDaZecIOnKL7SDqWDVfI8we6SLzk=
 github.com/GoogleCloudPlatform/cloudsql-proxy v0.0.0-20200114205427-eb5e09ef70a5/go.mod h1:Ea/RL9yv5P3ywzBLD00Ho3cXFm41q7DQf25Y4Kbg+nw=

--- a/resolvers/entry.go
+++ b/resolvers/entry.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	stripe "github.com/stripe/stripe-go"
@@ -144,10 +145,13 @@ func (r *mutationResolver) CreateEntry(ctx context.Context, input models.NewEntr
 		WordCount: input.WordCount,
 	}
 
-	res := wrabitDB.LogAndQueryRow(r.db, "INSERT INTO entries (user_id, content, word_count) VALUES ($1, $2, $3) RETURNING id", entry.UserID, entry.Content, entry.WordCount)
-	if err := res.Scan(&entry.ID); err != nil {
+	res := wrabitDB.LogAndExec(r.db, "INSERT INTO entries (user_id, content, word_count) VALUES ($1, $2, $3) RETURNING id", entry.UserID, entry.Content, entry.WordCount)
+	id, err := res.LastInsertId()
+	if err != nil {
 		panic(err)
 	}
+
+	entry.ID = strconv.FormatInt(id, 10)
 
 	return entry, nil
 }


### PR DESCRIPTION
This PR:
- [x] Changes the logic to see if a streak is valid for a donation
- [x] Saves on network and DB calls 